### PR TITLE
feat: Dockerfile, docker-compose, and .env files

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+POSTGRES_DB=food_delivery
+DATABASE_URL=jdbc:postgresql://postgres:5432/${POSTGRES_DB}
+POSTGRES_USER=user
+POSTGRES_PASSWORD=password

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM openjdk:8u121-alpine
+LABEL authors="Abdalla Khalifa, Yousef Shafee, Ahmed Basha"
+
+WORKDIR /app
+
+ARG JAR_FILE=food-delivery-app/target/food-delivery-app-0.0.1-SNAPSHOT.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]
+
+EXPOSE 8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+  postgres:
+    image: postgres:18.3-alpine
+    restart: unless-stopped
+    env_file:
+      - .env
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "${DB_USER}", "-d", "${DB_NAME}"]
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - ./food-delivery-app/src/main/resources/food_delivery.sql:/docker-entrypoint-initdb.d/init.sql
+    networks:
+      db-net:
+
+  application:
+    container_name: food-deliver
+    build: .
+    env_file:
+      - .env
+    ports:
+      - "8080:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - db-net
+      - api-net
+
+
+volumes:
+  postgres-data:
+    driver: local
+
+networks:
+  db-net:
+    driver: bridge
+    internal: true
+  api-net:
+    driver: bridge

--- a/food-delivery-app/src/main/resources/application.properties
+++ b/food-delivery-app/src/main/resources/application.properties
@@ -1,1 +1,8 @@
 spring.application.name=food-delivery-app
+spring.datasource.url=${DATABASE_URL}
+spring.datasource.username=${POSTGRES_USER}
+spring.datasource.password=${POSTGRES_PASSWORD}
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.datasource.driver-class-name=org.postgresql.Driver


### PR DESCRIPTION
closes #17    
 - Create docker file for our application created from opneJDK 21 alpine.
    - create docker compose file with internal and external networks and database volumes
    - the database variables are in the .env file.
    - refactore: application properties with datasource and jpa configurations.